### PR TITLE
Changed model to TemplateStaticState.modelName

### DIFF
--- a/src/main/webapp/js/lib/angular-table.js
+++ b/src/main/webapp/js/lib/angular-table.js
@@ -170,7 +170,7 @@ angular.module('angular-table', [])
                     }, true);
 
                     // check for scrollbars and adjust the header table width, and scrolling table height as needed when the number of bound rows changes
-                    scope.$watch('model', function(newValue, oldValue) {
+                    scope.$watch(TemplateStaticState.modelName, function(newValue, oldValue) {
                         // flip the booleans to trigger the watches
                         ResizeHeightEvent.fireTrigger = !ResizeHeightEvent.fireTrigger;
                         ResizeWidthEvent.fireTrigger = !ResizeWidthEvent.fireTrigger;


### PR DESCRIPTION
This PR is consistent with the last pulled merge which changed 'model' to TemplateStaticState.modelName.

The fixes the issue where upon changing the model the table doesn't trigger the resize event.
