### PR TITLE
Play nice with Grunt Wiredep

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "angularTable",
   "version": "1.1.0",
+  "main": ["src/main/webapp/css/lib/angular-table.css","src/main/webapp/js/lib/angular-table.css"],
   "dependencies": {
     "angular": "~1.0.7"
   },


### PR DESCRIPTION
The version currently published on Bower triggers warnings when using it with grunt-wiredep, because it doesn't know which files are to be included in the HTML.